### PR TITLE
Broadcast message when manifest download errors

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -255,9 +255,11 @@ async function UpdateCheck(isFirst)
 		// Always bypass cache when requesting offline.js to make sure we find out about new versions.
 		const response = await fetchWithBypass(OFFLINE_DATA_FILE, true);
 		
-		if (!response.ok)
+		if (!response.ok) {
+			Broadcast("offline-datafile-error");
 			throw new Error(OFFLINE_DATA_FILE + " responded with " + response.status + " " + response.statusText);
-			
+		}
+		
 		const data = await response.json();
 		
 		const version = data.version;


### PR DESCRIPTION
The service worker will broadcast a message if the
offline data file download errors